### PR TITLE
remove listFiles() from func renderIndex() 

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,12 +13,6 @@ import (
 const uploadPath = "./public"
 
 func renderIndex(w http.ResponseWriter, r *http.Request) {
-    files, err := listFiles(uploadPath)
-    if err != nil {
-        http.Error(w, "Unable to list files", http.StatusInternalServerError)
-        return
-    }
-
     tmpl, _ := template.ParseFiles("templates/home.html")
     tmpl.Execute(w, files)
 }


### PR DESCRIPTION
as we are calling the listfiles() in renderDocumentsPage(), there is no need to list files in renderIndex.